### PR TITLE
Add `Dockerfile` to the list of implicitly licensed files

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -13,6 +13,7 @@ Files:
   CODEOWNERS
   CODE_OF_CONDUCT.md
   CONTRIBUTING.md
+  Dockerfile
   Makefile
   go.mod
   go.sum


### PR DESCRIPTION
Fixes https://github.com/ironcore-dev/prometheus-dpdk-exporter/issues/27