### PR TITLE
Add heap info metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	r := prometheus.NewRegistry()
 	r.MustRegister(metrics.InterfaceStat)
 	r.MustRegister(metrics.CallCount)
+	r.MustRegister(metrics.HeapInfo)
 
 	http.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -46,6 +46,9 @@ func queryTelemetry(conn net.Conn, log *logrus.Logger, command string, response 
 }
 
 func Update(conn net.Conn, hostname string, log *logrus.Logger) {
+	var dpserviceHeapInfo DpServiceHeapInfo
+	queryTelemetry(conn, log, "/eal/heap_info", &dpserviceHeapInfo)
+
 	var ethdevList EthdevList
 	queryTelemetry(conn, log, "/ethdev/list", &ethdevList)
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -47,7 +47,13 @@ func queryTelemetry(conn net.Conn, log *logrus.Logger, command string, response 
 
 func Update(conn net.Conn, hostname string, log *logrus.Logger) {
 	var dpserviceHeapInfo DpServiceHeapInfo
-	queryTelemetry(conn, log, "/eal/heap_info", &dpserviceHeapInfo)
+	queryTelemetry(conn, log, "/eal/heap_info,0", &dpserviceHeapInfo)
+	for key, value := range dpserviceHeapInfo.Value {
+		// Only export metrics of type float64 (/eal/heap_info contains also some string values)
+		if v, ok := value.(float64); ok {
+			HeapInfo.With(prometheus.Labels{"node_name": hostname, "info": key}).Set(v)
+		}
+	}
 
 	var ethdevList EthdevList
 	queryTelemetry(conn, log, "/ethdev/list", &ethdevList)

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -9,7 +9,7 @@ var (
 	InterfaceStat = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "dpdk_interface_stat",
-			Help: "DPDK interface statistic",
+			Help: "Dp-Service interface statistic",
 		},
 		[]string{"interface", "stat_name"},
 	)
@@ -20,6 +20,14 @@ var (
 			Help: "Dp-Service graph statistics",
 		},
 		[]string{"node_name", "graph_node"},
+	)
+
+	HeapInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "dpdk_heap_info",
+			Help: "Dp-Service heap info",
+		},
+		[]string{"node_name", "info"},
 	)
 )
 
@@ -53,4 +61,8 @@ type GraphCallCount struct {
 
 type DpServiceGraphCallCount struct {
 	GraphCallCnt GraphCallCount `json:"/dp_service/graph/call_count"`
+}
+
+type DpServiceHeapInfo struct {
+	Value map[string]int `json:"/eal/heap_info"`
 }

--- a/metrics/types.go
+++ b/metrics/types.go
@@ -64,5 +64,5 @@ type DpServiceGraphCallCount struct {
 }
 
 type DpServiceHeapInfo struct {
-	Value map[string]int `json:"/eal/heap_info"`
+	Value map[string]any `json:"/eal/heap_info"`
 }


### PR DESCRIPTION
Added heap info metrics such as: Alloc_size, Free_size, Heap_size and more from /eal/heap_info
Only float64 metrics are exported as /eal/heap_info contains also some string values that are not needed.