### PR TITLE
Revert port number

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	flag.StringVar(&hostnameFlag, "hostname", "", "Hostname to use")
 	flag.IntVar(&pollIntervalFlag, "poll-interval", 20, "Polling interval in seconds")
-	flag.Uint64Var(&exporterPort, "port", 8080, "Port on which exporter will be running.")
+	flag.Uint64Var(&exporterPort, "port", 9064, "Port on which exporter will be running.")
 	flag.Parse()
 
 	if exporterPort < 1024 || exporterPort > 65535 {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var SocketPath = "/var/run/dpdk/rte/dpdk_telemetry.v2"
+const SocketPath = "/var/run/dpdk/rte/dpdk_telemetry.v2"
 
 func queryTelemetry(conn net.Conn, log *logrus.Logger, command string, response interface{}) {
 	_, err := conn.Write([]byte(command))


### PR DESCRIPTION
Revert the default port back to 9064 to match config of dpservice for more convenient deployment.

Change type of SocketPath from var to const as it should not be changed while running.